### PR TITLE
Switch Downloader to okHttp to support http/2 protocol

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,8 +22,10 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
     if (project.properties['android.useAndroidX'] == 'true' || project.properties['android.useAndroidX'] == true) {
-        api "androidx.tonyodev.fetch2okhttp:xfetch2okhttp:3.1.6"
+        implementation "androidx.tonyodev.fetch2okhttp:xfetch2okhttp:3.1.6"
+        api "androidx.tonyodev.fetch2:xfetch2:3.1.4"
     } else {
-        api "com.tonyodev.fetch2okhttp:fetch2okhttp:3.0.12"
+        implementation "com.tonyodev.fetch2okhttp:fetch2okhttp:3.0.12"
+        api "com.tonyodev.fetch2:fetch2:3.0.10"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
     if (project.properties['android.useAndroidX'] == 'true' || project.properties['android.useAndroidX'] == true) {
-        api "androidx.tonyodev.fetch2:xfetch2:3.1.4"
+        api "androidx.tonyodev.fetch2okhttp:xfetch2okhttp:3.1.6"
     } else {
-        api "com.tonyodev.fetch2:fetch2:3.0.10"
+        api "com.tonyodev.fetch2okhttp:fetch2okhttp:3.0.12"
     }
 }

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -24,6 +24,7 @@ import com.tonyodev.fetch2.Request;
 import com.tonyodev.fetch2.Status;
 import com.tonyodev.fetch2core.DownloadBlock;
 import com.tonyodev.fetch2core.Func;
+import com.tonyodev.fetch2core.Downloader;
 import com.tonyodev.fetch2okhttp.OkHttpDownloader;
 
 import org.jetbrains.annotations.NotNull;
@@ -85,7 +86,7 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
     loadConfigMap();
     FetchConfiguration fetchConfiguration = new FetchConfiguration.Builder(this.getReactApplicationContext())
             .setDownloadConcurrentLimit(20) // Set to the same value as your app's DOWNLOAD_CONCURRENCY_LIMIT
-            .setHttpDownloader(new OkHttpDownloader(okHttpClient))
+            .setHttpDownloader(new OkHttpDownloader(okHttpClient, Downloader.FileDownloaderType.PARALLEL))
             .setNamespace("RNBackgroundDownloader")
             .build();
     fetch = Fetch.Impl.getInstance(fetchConfiguration);

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -77,9 +77,12 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
   public RNBackgroundDownloaderModule(ReactApplicationContext reactContext) {
     super(reactContext);
 
+    OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
+
     loadConfigMap();
     FetchConfiguration fetchConfiguration = new FetchConfiguration.Builder(this.getReactApplicationContext())
             .setDownloadConcurrentLimit(20) // Set to the same value as your app's DOWNLOAD_CONCURRENCY_LIMIT
+            .setHttpDownloader(new OkHttpDownloader(okHttpClient))
             .setNamespace("RNBackgroundDownloader")
             .build();
     fetch = Fetch.Impl.getInstance(fetchConfiguration);

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -24,6 +24,7 @@ import com.tonyodev.fetch2.Request;
 import com.tonyodev.fetch2.Status;
 import com.tonyodev.fetch2core.DownloadBlock;
 import com.tonyodev.fetch2core.Func;
+import com.tonyodev.fetch2okhttp.OkHttpDownloader;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -39,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nullable;
+
+import okhttp3.OkHttpClient;
 
 public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule implements FetchListener {
 

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -24,7 +24,6 @@ import com.tonyodev.fetch2.Request;
 import com.tonyodev.fetch2.Status;
 import com.tonyodev.fetch2core.DownloadBlock;
 import com.tonyodev.fetch2core.Func;
-import com.tonyodev.fetch2core.Downloader;
 import com.tonyodev.fetch2okhttp.OkHttpDownloader;
 
 import org.jetbrains.annotations.NotNull;
@@ -86,7 +85,7 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
     loadConfigMap();
     FetchConfiguration fetchConfiguration = new FetchConfiguration.Builder(this.getReactApplicationContext())
             .setDownloadConcurrentLimit(20) // Set to the same value as your app's DOWNLOAD_CONCURRENCY_LIMIT
-            .setHttpDownloader(new OkHttpDownloader(okHttpClient, Downloader.FileDownloaderType.PARALLEL))
+            .setHttpDownloader(new OkHttpDownloader(okHttpClient))
             .setNamespace("RNBackgroundDownloader")
             .build();
     fetch = Fetch.Impl.getInstance(fetchConfiguration);


### PR DESCRIPTION
By switching the Downloader to OkHttp this allows us to now support http/2 on android devices. Previously we were using the default of HttpUrlConnection which doesn't support http2. This should bring a number of performance benefits and be more efficient in the handling of errors during downloads. 
